### PR TITLE
Add average block approval time output

### DIFF
--- a/simulator/src/main/java/simblock/simulator/Main.java
+++ b/simulator/src/main/java/simblock/simulator/Main.java
@@ -222,6 +222,10 @@ public class Main {
     OUT_JSON_FILE.print("]");
     OUT_JSON_FILE.close();
 
+    // Output average block approval time across all nodes
+    double avgApproval = Simulator.getAverageApprovalTime();
+    System.out.println("AverageApprovalTime:" + avgApproval);
+
     long end = System.currentTimeMillis();
     simulationTime += end - start;
     // Log simulation time in milliseconds

--- a/simulator/src/main/java/simblock/simulator/Simulator.java
+++ b/simulator/src/main/java/simblock/simulator/Simulator.java
@@ -100,6 +100,10 @@ public class Simulator {
   /** A list of observed {@link Block} instances. */
   private static final ArrayList<Block> observedBlocks = new ArrayList<>();
 
+
+  /** Recorded block approval times in milliseconds. */
+  private static final ArrayList<Long> approvalTimes = new ArrayList<>();
+
   /**
    * A list of observed block propagation times. The map key represents the id of the node that has
    * seen the block, the value represents the difference between the current time and the block
@@ -173,5 +177,23 @@ public class Simulator {
     for (int i = 0; i < observedBlocks.size(); i++) {
       printPropagation(observedBlocks.get(i), observedPropagations.get(i));
     }
+  }
+
+  /**
+   * Get the average block approval time across all observed blocks.
+   *
+   * @return the average propagation time in milliseconds
+   */
+  public static double getAverageApprovalTime() {
+    long sum = 0;
+    for (long t : approvalTimes) {
+      sum += t;
+    }
+    return approvalTimes.size() > 0 ? (double) sum / approvalTimes.size() / 1000.0 : 0.0;
+  }
+
+  /** Record a measured block approval time. */
+  public static void recordApprovalTime(long time) {
+    approvalTimes.add(time);
   }
 }

--- a/simulator/src/main/java/simblock/task/BlockApprovalTask.java
+++ b/simulator/src/main/java/simblock/task/BlockApprovalTask.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2019 Distributed Systems Group
+ *
+ * <p>Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package simblock.task;
+
+import static simblock.simulator.Timer.getCurrentTime;
+
+import simblock.block.Block;
+import simblock.node.Node;
+
+/** Task representing the validation of a received block. */
+public class BlockApprovalTask implements Task {
+  private final Node node;
+  private final Block block;
+  private final long startTime;
+
+  /**
+   * Instantiates a new Block approval task.
+   *
+   * @param node the node validating the block
+   * @param block the block to validate
+   */
+  public BlockApprovalTask(Node node, Block block) {
+    this.node = node;
+    this.block = block;
+    this.startTime = getCurrentTime();
+  }
+
+  @Override
+  public long getInterval() {
+    return this.node.getProcessingTime();
+  }
+
+  @Override
+  public void run() {
+    this.node.approveBlock(this.block, this.startTime);
+  }
+}


### PR DESCRIPTION
## Summary
- add `BlockApprovalTask` to model validation delay for each block
- record approval times in `Simulator` and compute their average
- schedule approval tasks in `Node.receiveBlock`
- print the average at the end of simulation
- convert reported approval time to seconds

## Testing
- `javac $(find simulator/src/main/java -name '*.java') -d /tmp/compile`


------
https://chatgpt.com/codex/tasks/task_e_687f349f79a8832284025296a80cabf8